### PR TITLE
Fixed #80: Stick Footer to the Bottom of the Page

### DIFF
--- a/src/app/store/store.component.html
+++ b/src/app/store/store.component.html
@@ -8,5 +8,5 @@
 <app-store-header></app-store-header>
 <div class="content">
   <router-outlet></router-outlet>
+  <app-store-footer></app-store-footer>
 </div>
-<app-store-footer></app-store-footer>


### PR DESCRIPTION
Footer is now being sticked to the bottom of the page, not the screen any more.
Fixed #80 