### PR TITLE
Api/add shippers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Follow deprecation of certain API paths as detailed in the changelog for API v1.1}
   - Use query parameters instead of path parameters for fetching single entities
 - Introduce `code` property in Image class as temporary identifier generated on server-side
+- Introduce `Shipper` class with a single `name` property as new entity model
 
 ### Fixed
 - Footer remains stuck at the bottom of the page, instead of the viewport.

--- a/src/app/api/api-service-injection-tokens.ts
+++ b/src/app/api/api-service-injection-tokens.ts
@@ -19,6 +19,7 @@ export const API_SERVICE_INJECTION_TOKENS = {
   dataProducts: 'ProductsDataApi',
   dataSales: 'SalesDataApi',
   dataSalespeople: 'SalespeopleDataApi',
+  dataShippers: 'ShippersDataApi',
   dataUserRoles: 'UserRolesDataApi',
   dataUsers: 'UsersDataApi',
   about: 'PublicAboutApi',

--- a/src/app/api/http/data/shippers-data.http-api.service.ts
+++ b/src/app/api/http/data/shippers-data.http-api.service.ts
@@ -31,13 +31,13 @@ export class ShippersDataHttpApiService
     );
   }
 
-  update(shipper: Shipper) {
+  update(shipper: Shipper, originalShipper?: Shipper) {
     return this.http.put(
       this.baseUrl,
       shipper,
       {
         params: new HttpParams({ fromObject: {
-          idNumber: String(shipper.name)
+          name: String(originalShipper.name)
         } })
       }
     );
@@ -48,7 +48,7 @@ export class ShippersDataHttpApiService
       this.baseUrl,
       {
         params: new HttpParams({ fromObject: {
-          idNumber: String(shipper.name)
+          name: String(shipper.name)
         } })
       }
     );

--- a/src/app/api/http/data/shippers-data.http-api.service.ts
+++ b/src/app/api/http/data/shippers-data.http-api.service.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Shipper } from 'src/app/models/entities/Shipper';
+import { IEntityDataApiService } from '../../entity.data-api.iservice';
+import { TransactionalEntityDataHttpApiService } from '../transactional-entity-data.http-api.abstract.service';
+
+@Injectable()
+export class ShippersDataHttpApiService
+  extends TransactionalEntityDataHttpApiService<Shipper>
+  implements IEntityDataApiService<Shipper> {
+
+  constructor(http: HttpClient) {
+    super(http, '/shippers');
+  }
+
+  fetchExisting(shipper: Shipper) {
+    return this.http.get<Shipper>(
+      this.baseUrl,
+      {
+        params: new HttpParams({ fromObject: {
+          name: String(shipper.name)
+        } })
+      }
+    );
+  }
+
+  update(shipper: Shipper) {
+    return this.http.put(
+      this.baseUrl,
+      shipper,
+      {
+        params: new HttpParams({ fromObject: {
+          idNumber: String(shipper.name)
+        } })
+      }
+    );
+  }
+
+  delete(shipper: Shipper) {
+    return this.http.delete(
+      this.baseUrl,
+      {
+        params: new HttpParams({ fromObject: {
+          idNumber: String(shipper.name)
+        } })
+      }
+    );
+  }
+}

--- a/src/app/api/http/http-api.module.ts
+++ b/src/app/api/http/http-api.module.ts
@@ -18,6 +18,7 @@ import { ProductCategoriesDataHttpApiService } from './data/product-categories-d
 import { ProductsDataHttpApiService } from './data/products-data.http-api.service';
 import { SalesDataHttpApiService } from './data/sales-data.http-api.service';
 import { SalespeopleDataHttpApiService } from './data/salespeople-data.http-api.service';
+import { ShippersDataHttpApiService } from './data/shippers-data.http-api.service';
 import { UserRolesDataHttpApiService } from './data/user-roles-data.http-api.service';
 import { UsersDataHttpApiService } from './data/users-data.http-api.service';
 import { AboutPublicHttpApiService } from './public/about-public.http-api.service';
@@ -80,6 +81,10 @@ import { SessionHttpApiInterceptor } from './session.http-api.interceptor';
     {
       provide: API_SERVICE_INJECTION_TOKENS.dataSalespeople,
       useClass: SalespeopleDataHttpApiService
+    },
+    {
+      provide: API_SERVICE_INJECTION_TOKENS.dataShippers,
+      useClass: ShippersDataHttpApiService
     },
     {
       provide: API_SERVICE_INJECTION_TOKENS.dataUserRoles,

--- a/src/app/api/local-memory/access/access.local-memory-api.service.ts
+++ b/src/app/api/local-memory/access/access.local-memory-api.service.ts
@@ -42,7 +42,7 @@ export class AccessLocalMemoryApiService
 
   public getAuthorizedAccess(): Observable<AuthorizedAccess> {
     return this.returnAsyncIfLoggedIn({
-      routes: ['customers', 'products', 'sales', 'salespeople', 'users', 'images']
+      routes: ['customers', 'products', 'sales', 'salespeople', 'users', 'images', 'shippers']
     });
   }
 

--- a/src/app/api/local-memory/data/shippers-data.local-memory-api.service.ts
+++ b/src/app/api/local-memory/data/shippers-data.local-memory-api.service.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { Injectable } from '@angular/core';
+import { Shipper } from 'src/app/models/entities/Shipper';
+import { MOCK_SHIPPERS } from '../mock/mock-shippers.datasource';
+import { TransactionalEntityDataLocalMemoryApiService } from '../transactional-entity-data.local-memory-api.abstract.service';
+
+@Injectable()
+export class ShippersDataLocalMemoryApiService
+  extends TransactionalEntityDataLocalMemoryApiService<Shipper> {
+
+  protected items = MOCK_SHIPPERS.slice();
+
+  constructor() {
+    super();
+  }
+
+  protected itemExists(shipper: Partial<Shipper>) {
+    return this.items.some(shipper2 => (shipper.name === shipper2.name));
+  }
+
+  protected getIndexOfItem(shipper: Partial<Shipper>) {
+    return this.items.findIndex(shipper2 => (shipper.name === shipper2.name));
+  }
+}

--- a/src/app/api/local-memory/local-memory-api.module.ts
+++ b/src/app/api/local-memory/local-memory-api.module.ts
@@ -7,26 +7,27 @@
 
 import { NgModule } from '@angular/core';
 import { API_SERVICE_INJECTION_TOKENS } from 'src/app/api/api-service-injection-tokens';
+import { AccessLocalMemoryApiService } from './access/access.local-memory-api.service';
+import { ProfileAccountLocalMemoryApiService } from './account/profile-account.local-memory-api.service';
+import { BillingTypesDataLocalMemoryApiService } from './data/billing-types-data.local-memory-api.service';
 import { CustomersDataLocalMemoryApiService } from './data/customers-data.local-memory-api.service';
-import { SalespeopleDataLocalMemoryApiService } from './data/salespeople-data.local-memory-api.service';
+import { ImagesDataLocalMemoryApiService } from './data/images-data.local-memory-api.service';
+import { PeopleDataLocalMemoryApiService } from './data/people-data.local-memory-api.service';
+import { ProductCategoriesDataLocalMemoryApiService } from './data/product-categories-data.local-memory-api.service';
 import { ProductsDataLocalMemoryApiService } from './data/products-data.local-memory-api.service';
 import { SalesDataLocalMemoryApiService } from './data/sales-data.local-memory-api.service';
-import { ProductCategoriesDataLocalMemoryApiService } from './data/product-categories-data.local-memory-api.service';
+import { SalespeopleDataLocalMemoryApiService } from './data/salespeople-data.local-memory-api.service';
+import { ShippersDataLocalMemoryApiService } from './data/shippers-data.local-memory-api.service';
+import { UserRolesDataLocalMemoryApiService } from './data/user-roles-data.local-memory-api.service';
 import { UsersDataLocalMemoryApiService } from './data/users-data.local-memory-api.service';
-import { AccessLocalMemoryApiService } from './access/access.local-memory-api.service';
-import { ImagesDataLocalMemoryApiService } from './data/images-data.local-memory-api.service';
-import { LoginPublicLocalMemoryApiService } from './public/login-public.local-memory-api.service';
 import { AboutPublicLocalMemoryApiService } from './public/about-public.local-memory-api.service';
 import { CategoriesPublicLocalMemoryApiService } from './public/categories-public.local-memory-api.service';
 import { CheckoutPublicLocalMemoryApiService } from './public/checkout-public.local-memory-api.service';
-import { ReceiptPublicLocalMemoryApiService } from './public/receipt-public.local-memory-api.service';
 import { GuestPublicLocalMemoryApiService } from './public/guest-public.local-memory-api.service';
-import { ProfileAccountLocalMemoryApiService } from './account/profile-account.local-memory-api.service';
-import { RegisterPublicLocalMemoryApiService } from './public/register-public.local-memory-api.service';
+import { LoginPublicLocalMemoryApiService } from './public/login-public.local-memory-api.service';
 import { ProductsPublicLocalMemoryApiService } from './public/products-public.local-memory-api.service';
-import { BillingTypesDataLocalMemoryApiService } from './data/billing-types-data.local-memory-api.service';
-import { PeopleDataLocalMemoryApiService } from './data/people-data.local-memory-api.service';
-import { UserRolesDataLocalMemoryApiService } from './data/user-roles-data.local-memory-api.service';
+import { ReceiptPublicLocalMemoryApiService } from './public/receipt-public.local-memory-api.service';
+import { RegisterPublicLocalMemoryApiService } from './public/register-public.local-memory-api.service';
 
 /**
  * Provides services that read and write data using the client's working memory
@@ -72,6 +73,10 @@ import { UserRolesDataLocalMemoryApiService } from './data/user-roles-data.local
     {
       provide: API_SERVICE_INJECTION_TOKENS.dataSalespeople,
       useClass: SalespeopleDataLocalMemoryApiService
+    },
+    {
+      provide: API_SERVICE_INJECTION_TOKENS.dataShippers,
+      useClass: ShippersDataLocalMemoryApiService
     },
     {
       provide: API_SERVICE_INJECTION_TOKENS.dataUserRoles,

--- a/src/app/api/local-memory/mock/mock-shippers.datasource.ts
+++ b/src/app/api/local-memory/mock/mock-shippers.datasource.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { Shipper } from 'src/app/models/entities/Shipper';
+
+export const MOCK_SHIPPERS: Shipper[] = [
+  { name: 'Shipper A' },
+  { name: 'Shipper B' }
+];

--- a/src/app/api/local-memory/transactional-entity-data.local-memory-api.abstract.service.ts
+++ b/src/app/api/local-memory/transactional-entity-data.local-memory-api.abstract.service.ts
@@ -102,14 +102,15 @@ export abstract class TransactionalEntityDataLocalMemoryApiService<T>
     );
   }
 
-  update(d: T) {
+  update(d: T, original?: T) {
     return new Observable<void>(
       observer => {
-        const existingItem = this.fetchExisting(d);
+        const index = original ? this.getIndexOfItem(original) : this.getIndexOfItem(d);
+        const existingItem = this.items[index];
         if (existingItem === null) {
           observer.error({ status: 404 });
         } else {
-          Object.assign(existingItem, d);
+          Object.assign(this.items[index], d);
           observer.next();
           observer.complete();
         }

--- a/src/app/api/transactional-entity.data-api.iservice.ts
+++ b/src/app/api/transactional-entity.data-api.iservice.ts
@@ -26,11 +26,13 @@ export interface ITransactionalEntityDataApiService<T>
 
   /**
    *
-   * @param item An object containing 1) The item's-class-own identifiying key-value
+   * @param itemLike An object containing 1) The item's-class-own identifiying key-value
    * property (such as id or code), and 2) All other properties to be updated, with
    * their respective new values.
+   * @param originalItem A copy of the item before any changes were made. Optional.
+   * NOTE: added temporarily to support update of Shippers
    */
-  update(itemLike: Partial<T>): Observable<any>;
+  update(itemLike: Partial<T>, originalItem?: T): Observable<any>;
 
   /**
    *

--- a/src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts
+++ b/src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts
@@ -69,6 +69,7 @@ export class DataManagerFormDialogComponent<T>
           this.dialog.close(item);
         },
         error => {
+          console.error(error);
           this.snackBarService.open(COMMON_ERROR_MESSAGE, COMMON_DISMISS_BUTTON_LABEL);
         }
       );

--- a/src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts
+++ b/src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts
@@ -28,7 +28,7 @@ export class DataManagerFormDialogComponent<T>
 
   busy$ = this.busySource.asObservable();
 
-  dialogTitle = 'Detalles del elemento';
+  dialogTitle = $localize `:Title of dialog used to view and edit some data:Element data`;
 
   @ViewChild(FormGroupOwnerOutletDirective, { static: true }) formGroupOutlet: FormGroupOwnerOutletDirective;
 
@@ -81,7 +81,7 @@ export class DataManagerFormDialogComponent<T>
   }
 
   private successMessage(item: T) {
-    return 'Elemento guardado con éxito';
+    return $localize `:Message of success after saving some data:Data saved successfully`;
   }
 
 }

--- a/src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts
+++ b/src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts
@@ -24,7 +24,7 @@ export class DataManagerFormDialogComponent<T>
 
   private busySource = new BehaviorSubject(true);
   private service: ITransactionalEntityDataApiService<T>;
-  private isNew = true;
+  private itemCopy = null;
 
   busy$ = this.busySource.asObservable();
 
@@ -48,7 +48,7 @@ export class DataManagerFormDialogComponent<T>
 
   ngOnInit(): void {
     if (this.data.item) {
-      this.isNew = false;
+      this.itemCopy = Object.assign({}, this.data.item);
     }
 
     this.busySource.next(false);
@@ -61,7 +61,7 @@ export class DataManagerFormDialogComponent<T>
       this.snackBarService.open(COMMON_VALIDATION_ERROR_MESSAGE, COMMON_DISMISS_BUTTON_LABEL);
     } else {
       const item = this.data.item;
-      const submitObservable = (this.isNew) ? this.service.create(item) : this.service.update(item);
+      const submitObservable = (!this.itemCopy) ? this.service.create(item) : this.service.update(item, this.itemCopy);
       submitObservable.subscribe(
         success => {
           const message = this.successMessage(item);

--- a/src/app/management/management-routing.module.ts
+++ b/src/app/management/management-routing.module.ts
@@ -21,6 +21,8 @@ import { SellManagerAccessResolver } from './routes/sales/sell-manager.access-re
 import { SellManagerComponent } from './routes/sales/sell-manager.component';
 import { SalespersonManagerAccessResolver } from './routes/salespeople/salesperson-manager.access-resolver';
 import { SalespersonManagerComponent } from './routes/salespeople/salesperson-manager.component';
+import { ShipperManagerAccessResolver } from './routes/shippers/shipper-manager.access-resolver';
+import { ShipperManagerComponent } from './routes/shippers/shipper-manager.component';
 import { UserManagerAccessResolver } from './routes/users/user-manager.access-resolver';
 import { UserManagerComponent } from './routes/users/user-manager.component';
 
@@ -58,7 +60,12 @@ export const MANAGEMENT_CHILD_ROUTES: ManagementChildRoute[] = [
     path: 'images', component: ImageManagerComponent,
     data: { matIcon: 'image', title: 'Imágenes' },
     resolve: { access: ImageManagerAccessResolver }
-  }
+  },
+  {
+    path: 'shippers', component: ShipperManagerComponent,
+    data: { matIcon: 'local_shipping', title: 'Repartidores' },
+    resolve: { access: ShipperManagerAccessResolver }
+  },
 ];
 
 const managementRoutes: Routes = [

--- a/src/app/management/management.module.ts
+++ b/src/app/management/management.module.ts
@@ -29,6 +29,8 @@ import { SellManagerComponent } from './routes/sales/sell-manager.component';
 import { SellManagerService } from './routes/sales/sell-manager.service';
 import { SalespersonManagerComponent } from './routes/salespeople/salesperson-manager.component';
 import { SalespersonManagerService } from './routes/salespeople/salesperson-manager.service';
+import { ShipperManagerComponent } from './routes/shippers/shipper-manager.component';
+import { ShipperManagerService } from './routes/shippers/shipper-manager.service';
 import { UserManagerComponent } from './routes/users/user-manager.component';
 import { UserManagerService } from './routes/users/user-manager.service';
 
@@ -49,6 +51,7 @@ const SNACKBAR_DEFAULTS: MatSnackBarConfig = {
     SalespersonManagerComponent,
     ProductManagerComponent,
     SellManagerComponent,
+    ShipperManagerComponent,
     UserManagerComponent,
     ImageManagerComponent,
     DataManagerFormDialogComponent
@@ -67,6 +70,7 @@ const SNACKBAR_DEFAULTS: MatSnackBarConfig = {
     ProductManagerService,
     UserManagerService,
     SellManagerService,
+    ShipperManagerService
   ]
 })
 export class ManagementModule { }

--- a/src/app/management/routes/shippers/shipper-manager.access-resolver.ts
+++ b/src/app/management/routes/shippers/shipper-manager.access-resolver.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { Inject, Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import { Observable } from 'rxjs';
+import { IAccessApiService } from 'src/app/api/access-api.iservice';
+import { API_SERVICE_INJECTION_TOKENS } from 'src/app/api/api-service-injection-tokens';
+import { AuthorizedAccess } from 'src/app/models/AuthorizedAccess';
+
+@Injectable({ providedIn: 'root' })
+export class ShipperManagerAccessResolver
+  implements Resolve<AuthorizedAccess> {
+
+  constructor(
+    @Inject(API_SERVICE_INJECTION_TOKENS.access) private apiAccessService: IAccessApiService
+  ) { }
+
+  resolve(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<AuthorizedAccess>|Promise<AuthorizedAccess>|AuthorizedAccess {
+    return this.apiAccessService.getResourceAuthorizedAccess('salespeople');
+  }
+}

--- a/src/app/management/routes/shippers/shipper-manager.component.css
+++ b/src/app/management/routes/shippers/shipper-manager.component.css
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+.mat-column-name {
+  max-width: 100%;
+}
+
+.mat-column-idNumber {
+  text-align: center;
+  max-width: 8rem;
+}

--- a/src/app/management/routes/shippers/shipper-manager.component.html
+++ b/src/app/management/routes/shippers/shipper-manager.component.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright (c) 2021 The Trébol eCommerce Project
+
+  This software is released under the MIT License.
+  https://opensource.org/licenses/MIT
+-->
+
+<app-centered-mat-spinner *ngIf="loading$ | async">
+</app-centered-mat-spinner>
+<div class="data-manager" [hidden]="loading$ | async">
+  <div class="table-wrapper">
+
+    <table mat-table class="full-width-min" [dataSource]="items$">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef> Nombre </th>
+        <td mat-cell *matCellDef="let shipper">
+          {{ shipper.name }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> </th>
+        <td mat-cell *matCellDef="let shipper">
+          <button mat-button mat-icon-button type="button"
+            *ngIf="canEdit$ | async"
+            color="primary"
+            [disabled]="busy$ | async"
+            (click)="onClickEdit(shipper)">
+            <mat-icon>edit</mat-icon>
+          </button>
+          <button mat-button mat-icon-button type="button"
+            *ngIf="canDelete$ | async"
+            color="warn"
+            [disabled]="busy$ | async"
+            (click)="onClickDelete(shipper)">
+            <mat-icon>delete</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="tableColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: tableColumns;"></tr>
+    </table>
+
+  </div>
+  <app-management-data-actions
+    *ngIf="canAdd$ | async"
+    (add)="onClickAdd()">
+  </app-management-data-actions>
+</div>

--- a/src/app/management/routes/shippers/shipper-manager.component.spec.ts
+++ b/src/app/management/routes/shippers/shipper-manager.component.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Output } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { CenteredMatProgressSpinnerComponent } from 'src/app/shared/components/centered-mat-spinner/centered-mat-spinner.component';
+import { ShipperManagerComponent } from './shipper-manager.component';
+import { ShipperManagerService } from './shipper-manager.service';
+
+@Component({ selector: 'app-management-data-actions' })
+class MockManagementDataActionsComponent {
+  @Output() add = new EventEmitter();
+}
+
+describe('ShippersManagerComponent', () => {
+  let component: ShipperManagerComponent;
+  let fixture: ComponentFixture<ShipperManagerComponent>;
+  let mockManagerService: Partial<ShipperManagerService>;
+  let mockSnackBarService: Partial<MatSnackBar>;
+  let mockDialogService: Partial<MatDialog>;
+
+  beforeEach(waitForAsync(() => {
+    mockManagerService = {
+      removeItems() { return of([true]); },
+      reloadItems() {},
+      loading$: of(false),
+      focusedItems$: of([]),
+      items$: of([]),
+      canEdit$: of(true),
+      canAdd$: of(true),
+      canDelete$: of(true),
+      updateAccess(acc) {}
+    };
+    mockSnackBarService = {
+      open(m: string, a: string) { return void 0; }
+    };
+    mockDialogService = {
+      open() { return void 0; }
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        CommonModule,
+        NoopAnimationsModule,
+        RouterTestingModule,
+        MatButtonModule,
+        MatIconModule,
+        MatProgressSpinnerModule,
+        MatTableModule,
+      ],
+      declarations: [
+        ShipperManagerComponent,
+        CenteredMatProgressSpinnerComponent,
+        MockManagementDataActionsComponent
+      ],
+      providers: [
+        { provide: ShipperManagerService, useValue: mockManagerService },
+        { provide: MatSnackBar, useValue: mockSnackBarService },
+        { provide: MatDialog, useValue: mockDialogService }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShipperManagerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/management/routes/shippers/shipper-manager.component.ts
+++ b/src/app/management/routes/shippers/shipper-manager.component.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs/operators';
+import { Shipper } from 'src/app/models/entities/Shipper';
+import { ShipperFormComponent } from 'src/app/shared/components/shipper-form/shipper-form.component';
+import { COMMON_WARNING_MESSAGE, COMMON_DISMISS_BUTTON_LABEL, COMMON_ERROR_MESSAGE } from 'src/text/messages';
+import { DataManagerFormDialogConfig } from '../../dialogs/data-manager-form-dialog/DataManagerFormDialogConfig';
+import { TransactionalDataManagerComponentDirective } from '../../directives/transactional-data-manager.component-directive';
+import { ShipperManagerService } from './shipper-manager.service';
+
+@Component({
+  selector: 'app-shipper-manager',
+  templateUrl: './shipper-manager.component.html',
+  styleUrls: [
+    '../data-manager.styles.css',
+    './shipper-manager.component.css'
+  ]
+})
+export class ShipperManagerComponent
+  extends TransactionalDataManagerComponentDirective<Shipper>
+  implements OnInit {
+
+  tableColumns: string[] = [ 'name', 'actions' ];
+
+  constructor(
+    protected service: ShipperManagerService,
+    protected dialogService: MatDialog,
+    private snackBarService: MatSnackBar,
+    private route: ActivatedRoute
+  ) {
+    super();
+  }
+
+  ngOnInit(): void {
+    super.init(this.service);
+    this.route.data.subscribe(
+      d => {
+        this.service.updateAccess(d.access);
+        this.service.reloadItems();
+      }
+    );
+  }
+
+  protected createDialogProperties(item: Shipper): DataManagerFormDialogConfig<Shipper> {
+    return {
+      data: {
+        item,
+        formComponent: ShipperFormComponent,
+        service: this.service.dataService
+      },
+      width: '40rem'
+    };
+  }
+
+  onClickDelete(shipper: Shipper) {
+    this.service.removeItems([shipper]).pipe(
+      map(results => results[0])
+    ).subscribe(
+      success => {
+        if (success) {
+          const successMessage = $localize`:Message of success after deleting a shipper with name {{ name }}:Shipper '${shipper.name}:name:' deleted`;
+          this.snackBarService.open(successMessage, COMMON_DISMISS_BUTTON_LABEL);
+          this.service.reloadItems();
+        } else {
+          this.snackBarService.open(COMMON_WARNING_MESSAGE, COMMON_DISMISS_BUTTON_LABEL);
+        }
+      },
+      error => {
+        this.snackBarService.open(COMMON_ERROR_MESSAGE, COMMON_DISMISS_BUTTON_LABEL);
+      }
+    );
+  }
+
+}

--- a/src/app/management/routes/shippers/shipper-manager.service.spec.ts
+++ b/src/app/management/routes/shippers/shipper-manager.service.spec.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { LocalMemoryApiModule } from 'src/app/api/local-memory/local-memory-api.module';
+import { ShipperManagerService } from './shipper-manager.service';
+
+describe('ShippersManagerService', () => {
+  let service: ShipperManagerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ LocalMemoryApiModule ],
+      providers: [
+        ShipperManagerService
+      ]
+    });
+    service = TestBed.inject(ShipperManagerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/management/routes/shippers/shipper-manager.service.ts
+++ b/src/app/management/routes/shippers/shipper-manager.service.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { Inject, Injectable } from '@angular/core';
+import { API_SERVICE_INJECTION_TOKENS } from 'src/app/api/api-service-injection-tokens';
+import { ITransactionalEntityDataApiService } from 'src/app/api/transactional-entity.data-api.iservice';
+import { Shipper } from 'src/app/models/entities/Shipper';
+import { TransactionalDataManagerServiceDirective } from '../../directives/transactional-data-manager.service-directive';
+
+@Injectable()
+export class ShipperManagerService
+  extends TransactionalDataManagerServiceDirective<Shipper> {
+
+  constructor(
+    @Inject(API_SERVICE_INJECTION_TOKENS.dataShippers) public dataService: ITransactionalEntityDataApiService<Shipper>
+  ) {
+    super();
+  }
+}

--- a/src/app/models/entities/Shipper.ts
+++ b/src/app/models/entities/Shipper.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+export class Shipper {
+  name: string;
+}

--- a/src/app/shared/components/shipper-form/shipper-form.component.css
+++ b/src/app/shared/components/shipper-form/shipper-form.component.css
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+form {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}

--- a/src/app/shared/components/shipper-form/shipper-form.component.html
+++ b/src/app/shared/components/shipper-form/shipper-form.component.html
@@ -1,0 +1,15 @@
+<!--
+  Copyright (c) 2021 The Trébol eCommerce Project
+
+  This software is released under the MIT License.
+  https://opensource.org/licenses/MIT
+-->
+
+<form [formGroup]="formGroup">
+  <mat-form-field class="name">
+    <input matInput formControlName="name"
+      placeholder="Name"
+      i18n-placeholder="Name of field for the identifiying name of a shipper or shipping service"
+      (blur)="onTouched()" />
+  </mat-form-field>
+</form>

--- a/src/app/shared/components/shipper-form/shipper-form.component.spec.ts
+++ b/src/app/shared/components/shipper-form/shipper-form.component.spec.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ShipperFormComponent } from './shipper-form.component';
+
+describe('ShipperFormComponent', () => {
+  let component: ShipperFormComponent;
+  let fixture: ComponentFixture<ShipperFormComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule
+      ],
+      declarations: [ ShipperFormComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShipperFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/shipper-form/shipper-form.component.ts
+++ b/src/app/shared/components/shipper-form/shipper-form.component.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021 The Trébol eCommerce Project
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+import { Component, EventEmitter, OnDestroy } from '@angular/core';
+import {
+  AbstractControl, ControlValueAccessor, FormBuilder, FormControl, FormGroup, NG_VALIDATORS,
+  NG_VALUE_ACCESSOR, ValidationErrors, Validator, Validators
+} from '@angular/forms';
+import { Subscription } from 'rxjs';
+import { debounceTime, tap } from 'rxjs/operators';
+import { isJavaScriptObject } from 'src/functions/isJavaScriptObject';
+
+@Component({
+  selector: 'app-shipper-form',
+  templateUrl: './shipper-form.component.html',
+  styleUrls: ['./shipper-form.component.css'],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      multi: true,
+      useExisting: ShipperFormComponent
+    },
+    {
+      provide: NG_VALIDATORS,
+      multi: true,
+      useExisting: ShipperFormComponent
+    }
+  ]
+})
+export class ShipperFormComponent
+  implements OnDestroy, ControlValueAccessor, Validator {
+
+  private touchedSubscriptions: Subscription[] = [];
+  private valueChangesSubscriptions: Subscription[] = [];
+  private touched = new EventEmitter<void>();
+
+  formGroup: FormGroup;
+
+  get name() { return this.formGroup.get('name') as FormControl; }
+
+  constructor(
+    private formBuilder: FormBuilder
+  ) {
+    this.formGroup = this.formBuilder.group({
+      name: ['', Validators.required]
+    });
+  }
+
+  ngOnDestroy(): void {
+    for (const sub of [
+      ...this.touchedSubscriptions,
+      ...this.valueChangesSubscriptions]) {
+      sub.unsubscribe();
+    }
+    this.touched.complete();
+  }
+
+  onTouched(): void {
+    this.touched.emit();
+  }
+
+  writeValue(obj: any): void {
+    this.name.reset('', { emitEvent: false });
+    if (isJavaScriptObject(obj)) {
+      this.formGroup.patchValue(obj, { emitEvent: false });
+    }
+  }
+
+  registerOnChange(fn: (value: any) => void): void {
+    const sub = this.formGroup.valueChanges.pipe(debounceTime(150), tap(fn)).subscribe();
+    this.valueChangesSubscriptions.push(sub);
+  }
+
+  registerOnTouched(fn: () => void): void {
+    const sub = this.touched.pipe(tap(fn)).subscribe();
+    this.touchedSubscriptions.push(sub);
+  }
+
+  setDisabledState?(isDisabled: boolean): void {
+    if (isDisabled) {
+      this.formGroup.disable({ emitEvent: false });
+    } else {
+      this.formGroup.enable({ emitEvent: false });
+    }
+  }
+
+  validate(control: AbstractControl): ValidationErrors | null {
+    const errors = {} as any;
+    const value = control.value;
+    if (value) {
+      if (!value.name) {
+        errors.requiredShipperName = value.name;
+      }
+
+      if (JSON.stringify(errors) !== '{}') {
+        return errors;
+      }
+    }
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -23,6 +23,7 @@ import { ProductFiltersPanelComponent } from './components/product-filters-panel
 import { ProductFormComponent } from './components/product-form/product-form.component';
 import { SalespersonFormComponent } from './components/salesperson-form/salesperson-form.component';
 import { SellFormComponent } from './components/sell-form/sell-form.component';
+import { ShipperFormComponent } from './components/shipper-form/shipper-form.component';
 import { SlideshowComponent } from './components/slideshow/slideshow.component';
 import { UserFormComponent } from './components/user-form/user-form.component';
 import { AddressFormDialogComponent } from './dialogs/address-form/address-form-dialog.component';
@@ -47,6 +48,7 @@ const PUBLIC_COMPONENTS = [
   ProductFormComponent,
   SalespersonFormComponent,
   SellFormComponent,
+  ShipperFormComponent,
   UserFormComponent,
   ProductFiltersPanelComponent,
   EditProfileFormDialogComponent,

--- a/src/locales/messages.en-US.xlf
+++ b/src/locales/messages.en-US.xlf
@@ -15,6 +15,22 @@
         <note priority="1" from="description">Label to notify user that they have logged out</note>
         <note priority="1" from="meaning">logout message</note>
       </trans-unit>
+      <trans-unit id="2927965659351774265" datatype="html">
+        <source>Element data</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <note priority="1" from="description">Title of dialog used to view and edit some data</note>
+      </trans-unit>
+      <trans-unit id="2185228394767497497" datatype="html">
+        <source>Data saved successfully</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <note priority="1" from="description">Message of success after saving some data</note>
+      </trans-unit>
       <trans-unit id="7271324698069692652" datatype="html">
         <source>Image &apos;<x id="PH" equiv-text="img.filename"/>&apos;:fileName: deleted</source>
         <context-group purpose="location">
@@ -46,6 +62,14 @@
           <context context-type="linenumber">70</context>
         </context-group>
         <note priority="1" from="description">Message of success after deleting a salesperson with first name {{ firstName }} and last name {{ lastName }}</note>
+      </trans-unit>
+      <trans-unit id="4322964496601388916" datatype="html">
+        <source>Shipper &apos;<x id="name" equiv-text="shipper.name"/>&apos; deleted</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/management/routes/shippers/shipper-manager.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+        <note priority="1" from="description">Message of success after deleting a shipper with name {{ name }}</note>
       </trans-unit>
       <trans-unit id="5c7012b5a926b32d9e45fefdcc8a1a3cb6f023d0" datatype="html">
         <source>City</source>
@@ -525,6 +549,14 @@
         </context-group>
         <note priority="1" from="description">Label with sell total value (products, transport and taxes) being {{ totalValue }}</note>
         <note priority="1" from="meaning">total sell value</note>
+      </trans-unit>
+      <trans-unit id="cff1428d10d59d14e45edec3c735a27b5482db59" datatype="html">
+        <source>Name</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/shipper-form/shipper-form.component.html</context>
+          <context context-type="linenumber">11</context>
+        </context-group>
+        <note priority="1" from="description">Name of field for the identifiying name of a shipper or shipping service</note>
       </trans-unit>
       <trans-unit id="44ad6e8ded61058a394ed7b1486cbf0aca144198" datatype="html">
         <source>Unavailable image</source>

--- a/src/locales/messages.es-CL.xlf
+++ b/src/locales/messages.es-CL.xlf
@@ -15,6 +15,22 @@
         <note priority="1" from="description">Label to notify user that they have logged out</note>
         <note priority="1" from="meaning">logout message</note>
       </trans-unit>
+      <trans-unit id="2927965659351774265" datatype="html">
+        <source>Datos del elemento</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <note priority="1" from="description">Title of dialog used to view and edit some data</note>
+      </trans-unit>
+      <trans-unit id="2185228394767497497" datatype="html">
+        <source>Elemento guardado exitosamente</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <note priority="1" from="description">Message of success after saving some data</note>
+      </trans-unit>
       <trans-unit id="7271324698069692652" datatype="html">
         <source>Imagen &apos;<x id="PH" equiv-text="img.filename"/>&apos;:fileName: eliminada</source>
         <context-group purpose="location">

--- a/src/locales/messages.es.xlf
+++ b/src/locales/messages.es.xlf
@@ -15,6 +15,22 @@
         <note priority="1" from="description">Label to notify user that they have logged out</note>
         <note priority="1" from="meaning">logout message</note>
       </trans-unit>
+      <trans-unit id="2927965659351774265" datatype="html">
+        <source>Datos del elemento</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts</context>
+          <context context-type="linenumber">31</context>
+        </context-group>
+        <note priority="1" from="description">Title of dialog used to view and edit some data</note>
+      </trans-unit>
+      <trans-unit id="2185228394767497497" datatype="html">
+        <source>Elemento guardado exitosamente</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/management/dialogs/data-manager-form-dialog/data-manager-form-dialog.component.ts</context>
+          <context context-type="linenumber">84</context>
+        </context-group>
+        <note priority="1" from="description">Message of success after saving some data</note>
+      </trans-unit>
       <trans-unit id="7271324698069692652" datatype="html">
         <source>Imagen &apos;<x id="PH" equiv-text="img.filename"/>&apos;:fileName: eliminada</source>
         <context-group purpose="location">


### PR DESCRIPTION
This PR must resolve #89 

- [x] `Shipper` class
- [x] Injection token for api client services, see `src/app/api/api-service-injection-tokens.ts`
- [x] Implementation of the `ITransactionalEntityDataApiService<T>` interface inside the `http` and `local-memory` api module
- [x] Provider for corresponding implementation under the aforementioned injection token on each api module
- [x] Corresponding form component, see `src/app/shared/components/` for examples
- [x] Routed component like the existing ones in `src/management/routes/`
- [x] Route to that component inside `src/management/management-routing.module.ts`